### PR TITLE
feat: adding local fallback and updating assume role capabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,8 @@ inThisBuild(
   List(
     name := "unistore",
     organization := "com.lumidion",
-    homepage := Some(url("https://github.com/lumidion/unistore")),
+    description := "Unistore is a library for a parsing single files in a cloud-agnostic manner, most commonly for application configuration.",
+    homepage := Some(url("https://www.lumidion.com")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(
@@ -13,7 +14,7 @@ inThisBuild(
         email = "david@lumidion.com",
         url = url("https://www.lumidion.com/about")
       )
-    )
+    ),
   )
 )
 
@@ -25,13 +26,19 @@ lazy val root = (project in file("."))
   )
   .settings(
     name := "unistore",
-    scalaVersion := scala3.value,
-    scalacOptions ++= Seq(
-      "-Werror",
-      "-Wunused:all",
-      "-deprecation",
-      "-source:future"
-    ),
+    crossScalaVersions := Seq(scala3.value, scala213.value),
+    scalacOptions ++= {
+      if (scalaVersion.value == scala3.value) {
+        Seq(
+          "-Werror",
+          "-Wunused:all",
+          "-deprecation"
+        )
+      } else
+        Seq(
+          "-Xsource:3"
+        )
+    },
     libraryDependencies := Seq(
       "dev.zio" %% "zio-aws-s3" % "7.21.15.7",
       "dev.zio" %% "zio-aws-sts" % "7.21.15.7",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ inThisBuild(
         email = "david@lumidion.com",
         url = url("https://www.lumidion.com/about")
       )
-    ),
+    )
   )
 )
 

--- a/src/main/scala/com/lumidion/unistore/clients/AwsS3Client.scala
+++ b/src/main/scala/com/lumidion/unistore/clients/AwsS3Client.scala
@@ -1,9 +1,9 @@
 package com.lumidion.unistore.clients
 
+import com.lumidion.unistore.clients.AwsS3Client.defaultRegion
 import com.lumidion.unistore.config.AwsS3StorageConfig
 import com.lumidion.unistore.models.errors.{ConfigError, FileRetrievalError, UnistoreError}
-import com.lumidion.unistore.utils.Extensions.ZIOOps.*
-import com.lumidion.unistore.utils.Extensions.ZLayerOps.*
+import com.lumidion.unistore.utils.Extensions.{ZIOOps, ZLayerOps}
 
 import zio.{ZIO, ZLayer}
 import zio.aws.core.config.{AwsConfig, ClientCustomization}
@@ -14,6 +14,7 @@ import zio.aws.s3.S3.getObject
 import zio.stream.ZSink
 
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
+import software.amazon.awssdk.regions.Region
 
 private[unistore] class AwsS3Client(config: AwsS3StorageConfig) extends StorageClient {
 
@@ -23,7 +24,8 @@ private[unistore] class AwsS3Client(config: AwsS3StorageConfig) extends StorageC
         AwsConfig.customized(new ClientCustomization {
           override def customize[Client, Builder <: AwsClientBuilder[Builder, Client]](
               builder: Builder
-          ): Builder = builder.credentialsProvider(provider)
+          ): Builder =
+            builder.credentialsProvider(provider).region(config.region.getOrElse(defaultRegion))
         })
       }
       .getOrElse(AwsConfig.default)
@@ -46,4 +48,8 @@ private[unistore] class AwsS3Client(config: AwsS3StorageConfig) extends StorageC
     }
       .provideLayer(layer)
   }
+}
+
+private[unistore] object AwsS3Client {
+  val defaultRegion: Region = Region.US_WEST_1
 }

--- a/src/main/scala/com/lumidion/unistore/clients/LocalStorageClient.scala
+++ b/src/main/scala/com/lumidion/unistore/clients/LocalStorageClient.scala
@@ -2,18 +2,24 @@ package com.lumidion.unistore.clients
 
 import com.lumidion.unistore.config.LocalStorageConfig
 import com.lumidion.unistore.models.errors.{FileRetrievalError, UnistoreError}
-import com.lumidion.unistore.utils.Extensions.ZIOOps.*
+import com.lumidion.unistore.utils.Extensions.ZIOOps
 
 import zio.stream.{ZSink, ZStream}
 import zio.ZIO
 
+import java.io.File
+
 private[unistore] class LocalStorageClient(config: LocalStorageConfig) extends StorageClient {
   def loadFile: ZIO[Any, UnistoreError, Array[Byte]] =
     ZStream
-      .fromFile(java.io.File(config.filePath))
+      .fromFile(new File(config.filePath))
       .run(ZSink.collectAll)
       .map(_.toArray)
       .leftZIOToAppErr(err =>
-        FileRetrievalError(new Exception(s"Could not load file at path: ${config.filePath}"))
+        FileRetrievalError(
+          new Exception(
+            s"Could not load file at path: ${config.filePath}. Error message: ${err.getMessage}"
+          )
+        )
       )
 }

--- a/src/main/scala/com/lumidion/unistore/config/package.scala
+++ b/src/main/scala/com/lumidion/unistore/config/package.scala
@@ -1,7 +1,5 @@
 package com.lumidion.unistore
 
-import com.lumidion.unistore.utils.Extensions.ZLayerOps.*
-
 import zio.aws.core.AwsError
 import zio.aws.s3.model.primitives.{BucketName, ObjectKey}
 import zio.aws.sts.model.AssumeRoleRequest
@@ -12,15 +10,18 @@ import zio.ZIO
 import software.amazon.awssdk.auth.credentials.{
   AwsBasicCredentials,
   AwsCredentialsProvider,
+  AwsSessionCredentials,
   StaticCredentialsProvider
 }
+import software.amazon.awssdk.regions.Region
 
 package object config {
   sealed trait StorageConfig
 
-  final case class AwsS3StorageConfig private (
+  final case class AwsS3StorageConfig(
       bucketName: BucketName,
       objectKey: ObjectKey,
+      region: Option[Region],
       configuredCredentialsProvider: Option[AwsCredentialsProvider]
   ) extends StorageConfig
 
@@ -28,27 +29,31 @@ package object config {
     def fromAssumeRoleRequest(
         bucketName: String,
         objectKey: String,
-        request: AssumeRoleRequest
+        request: AssumeRoleRequest,
+        region: Option[Region]
     ): ZIO[Sts, AwsError, AwsS3StorageConfig] = for {
       res <- assumeRole(request)
       credentials <- res.getCredentials
-      awsCredentials = AwsBasicCredentials.create(
+      awsCredentials = AwsSessionCredentials.create(
         credentials.accessKeyId,
-        credentials.secretAccessKey
+        credentials.secretAccessKey,
+        credentials.sessionToken
       )
       provider = StaticCredentialsProvider.create(awsCredentials)
-    } yield AwsS3StorageConfig(BucketName(bucketName), ObjectKey(objectKey), Some(provider))
+    } yield AwsS3StorageConfig(BucketName(bucketName), ObjectKey(objectKey), region, Some(provider))
 
     def fromBasicCredentials(
         bucketName: String,
         objectKey: String,
         accessKeyId: String,
-        secretAccessKey: String
+        secretAccessKey: String,
+        region: Option[Region]
     ): ZIO[Any, Nothing, AwsS3StorageConfig] =
       ZIO.succeed(
         AwsS3StorageConfig(
           BucketName(bucketName),
           ObjectKey(objectKey),
+          region,
           Some(
             StaticCredentialsProvider.create(
               AwsBasicCredentials.create(accessKeyId, secretAccessKey)
@@ -61,7 +66,7 @@ package object config {
         bucketName: String,
         objectKey: String
     ): ZIO[Any, Nothing, AwsS3StorageConfig] =
-      ZIO.succeed(AwsS3StorageConfig(BucketName(bucketName), ObjectKey(objectKey), None))
+      ZIO.succeed(AwsS3StorageConfig(BucketName(bucketName), ObjectKey(objectKey), None, None))
   }
 
   final case class LocalStorageConfig(filePath: String) extends StorageConfig

--- a/src/main/scala/com/lumidion/unistore/models/errors/package.scala
+++ b/src/main/scala/com/lumidion/unistore/models/errors/package.scala
@@ -1,7 +1,7 @@
 package com.lumidion.unistore.models
 
 package object errors {
-  sealed trait UnistoreError {
+  sealed trait UnistoreError extends Exception {
     val errorName: String
     val ex: Exception
   }

--- a/src/main/scala/com/lumidion/unistore/utils/Extensions.scala
+++ b/src/main/scala/com/lumidion/unistore/utils/Extensions.scala
@@ -1,21 +1,38 @@
 package com.lumidion.unistore.utils
 
-import com.lumidion.unistore.models.errors.UnistoreError
+import com.lumidion.unistore.models.errors.{ConfigError, UnistoreError}
 
 import zio.{Tag, ZIO, ZLayer}
 
+import scala.jdk.CollectionConverters.*
+import software.amazon.awssdk.regions.Region
+
 private[unistore] object Extensions {
-  object ZIOOps {
-    extension [R, E, A](value: ZIO[R, E, A])
-      def leftZIOToAppErr(func: E => UnistoreError): ZIO[R, UnistoreError, A] =
-        value.foldZIO(err => ZIO.fail(func(err)), res => ZIO.succeed(res))
+
+  implicit class OptionStringOps(value: Option[String]) {
+    private lazy val regionsById =
+      Region.regions().asScala.map(region => (region.id(), region)).toMap
+
+    def toRegion: ZIO[Any, UnistoreError, Option[Region]] = {
+      value.fold[ZIO[Any, UnistoreError, Option[Region]]](ZIO.none) { regionId =>
+        ZIO.fromEither {
+          regionsById
+            .get(regionId)
+            .toRight(ConfigError(new Exception(s"Invalid region id given. Region id: $regionId")))
+        }.asSome
+      }
+    }
   }
 
-  object ZLayerOps {
-    extension [R, E, A](value: ZLayer[R, E, A])
-      def leftZLayerToAppErr(func: E => UnistoreError)(implicit
-          tag: Tag[A]
-      ): ZLayer[R, UnistoreError, A] =
-        value.foldLayer(err => ZLayer.fail(func(err)), res => ZLayer.succeed(res.get))
+  implicit class ZIOOps[R, E, A](value: ZIO[R, E, A]) {
+    def leftZIOToAppErr(func: E => UnistoreError): ZIO[R, UnistoreError, A] =
+      value.foldZIO(err => ZIO.fail(func(err)), res => ZIO.succeed(res))
+  }
+
+  implicit class ZLayerOps[R, E, A](value: ZLayer[R, E, A]) {
+    def leftZLayerToAppErr(func: E => UnistoreError)(implicit
+        tag: Tag[A]
+    ): ZLayer[R, UnistoreError, A] =
+      value.foldLayer(err => ZLayer.fail(func(err)), res => ZLayer.succeed(res.get))
   }
 }


### PR DESCRIPTION
## Description
This PR enables support for Scala 2.13 and adds new options to the unistore client so that users can better assume AWS roles across multiple environments. As part of the new options, it enables applications to set a user-specified local path option, as well as an application-specified local path option.

The following are the new client options
```scala
class UnistoreClient(
    //...
    awsRegion: Option[String] = None,
    localFilePath: Option[String] = None, //useful where applications want to leave this to the end-user to specify
    localFallbackFilePath: Option[String] = None, //useful where applications want to set a default file path
) 
```

Additionally, all unistore errors now extend `Exception` so that effects can form a straightforward ZIO Task that can easily be converted to an effect with a throwable error channel (like `cats.effect.IO`).